### PR TITLE
Resolve deprecation warning

### DIFF
--- a/qsstats/utils.py
+++ b/qsstats/utils.py
@@ -15,7 +15,7 @@ def _to_datetime(dt):
 
 def _parse_interval(interval):
     num = 1
-    match = re.match('(\d+)([A-Za-z]+)', interval)
+    match = re.match(r'(\d+)([A-Za-z]+)', interval)
 
     if match:
         num = int(match.group(1))


### PR DESCRIPTION
Hit running tests with latest pytest

```
  /Users/alancoding/.virtualenvs/awx_collection/lib/python3.6/site-packages/qsstats/utils.py:18: DeprecationWarning: invalid escape sequence \d
    match = re.match('(\d+)([A-Za-z]+)', interval)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
```

rationale for this: https://stackoverflow.com/questions/50504500/deprecationwarning-invalid-escape-sequence-what-to-use-instead-of-d#comment97796479_50504635